### PR TITLE
Chrome has changed URL of images settings page

### DIFF
--- a/core.js
+++ b/core.js
@@ -291,7 +291,7 @@ function toggleContextMenu() {
 
 function openImgPanel() {
 	return function(info, tab) {
-		chrome.tabs.create({"url":"chrome://chrome/settings/contentExceptions#images", "selected":true});
+		chrome.tabs.create({"url":"chrome://settings/content/images", "selected":true});
 	};
 }
 


### PR DESCRIPTION
I just found your extension today and noticed the settings link is outdated